### PR TITLE
Add write-permission handling and robust import fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ PERSONAL_*
 PRIVATE_*
 *_PRIVATE.*
 *_PERSONAL.*
+test/

--- a/config/settings.json
+++ b/config/settings.json
@@ -2,8 +2,8 @@
   "language": "en_US",
   "first_run": false,
   "window_geometry": "680x780",
-  "last_selected_ide": "Cursor",
+  "last_selected_ide": "VS Code",
   "show_welcome": false,
-  "show_about_on_startup": true,
+  "show_about_on_startup": false,
   "theme": "default"
 }


### PR DESCRIPTION
- Ensure target files are writable before patching via _ensure_write_permissions()
- Add cross-platform (Windows/POSIX) permission checks using stat & chmod
- Make language_manager and common_utils imports resilient to missing modules
- Provide fallback implementations for CLI testing outside the package